### PR TITLE
Encode savedSelector in add-on URL

### DIFF
--- a/bookmarklet/klaxon.html
+++ b/bookmarklet/klaxon.html
@@ -168,7 +168,8 @@
 
       document.getElementById("edit-button").addEventListener('click', function(e) {
         const urlParams = new URLSearchParams(location.search);
-        window.open(`https://www.documentcloud.org/add-ons/MuckRock/Klaxon/?site=${urlParams.get("url")}&selector=${savedSelector}&event=hourly`);
+        const selector = encodeURIComponent(savedSelector);
+        window.open(`https://www.documentcloud.org/add-ons/MuckRock/Klaxon/?site=${urlParams.get("url")}&selector=${selector}&event=hourly`);
       }, false);
 
 


### PR DESCRIPTION
Fixes #19 by ensuring selectors containing IDs get encoded correctly into the URL